### PR TITLE
Configure the npm cache per install

### DIFF
--- a/bin/install_node
+++ b/bin/install_node
@@ -59,3 +59,7 @@ if [ "$platform" != "win32" ]; then
 else
     cp node.exe "$output_dir/"
 fi
+
+# Change the location of the npm cache so different versions of node don't interfere with each other
+mkdir -p "$output_dir/.npm"
+"$output_dir/lib/node_modules/npm/configure" --cache="$output_dir/.npm"


### PR DESCRIPTION
Prevents npm cache interference between multiple node installations.

cc @jfirebaugh 
