### PR TITLE
Move verification step into recache

### DIFF
--- a/bin/install_node
+++ b/bin/install_node
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/bin/bash 
 set -eu
 
 bin_only="false"
@@ -73,39 +72,6 @@ cd "$tmp"
 
 # Download node
 curl -Lsfo $(basename $url) "$url"
-
-# Only verify SHASUMS.txt.asc if found.
-if curl -sf "$INSTALL_NODE_URL/v$node_version/SHASUMS.txt.asc" > /dev/null; then
-    curl -Lsfo izs.asc "https://s3.amazonaws.com/mapbox/apps/install-node/cache/izs.asc"
-    curl -Lsfo tjfontaine.asc "https://s3.amazonaws.com/mapbox/apps/install-node/cache/tjfontaine.asc"
-    curl -Lsfo SHASUMS.txt.asc "$INSTALL_NODE_URL/v$node_version/SHASUMS.txt.asc"
-
-    if which gpg > /dev/null; then
-        # Add trusted gpg keys for verifying nodejs downloads
-        gpg --import izs.asc
-        gpg --import tjfontaine.asc
-
-        # Verify signed SHASUMS file to ensure it can be trusted
-        echo "Verifying signature of nodejs SHASUMS.txt.asc"
-        gpg --verify < "SHASUMS.txt.asc"
-    else
-        echo "WARNING: gpg not found. Installing node without verifying SHASUMS.txt.asc" >&2
-    fi
-
-    # RHEL/centos7 does not ship with a parent shasum function.
-    # Fallback to sha1sum if not found.
-    shasum=""
-    if which shasum > /dev/null; then
-        shasum=$(which shasum)
-    elif which sha1sum > /dev/null; then
-        shasum=$(which sha1sum)
-    fi
-
-    # Check that shasum of tarball is present
-    echo "Verifying nodejs shasum"
-    node_shasum="$($shasum $(basename $url) | grep -oE '^[0-9a-f]+')"
-    grep "$node_shasum" "SHASUMS.txt.asc"
-fi
 
 # Install node
 if [ "$platformarch" != "win32-ia32" ] && [ "$platformarch" != "win32-x64" ]; then

--- a/util/recache
+++ b/util/recache
@@ -17,6 +17,21 @@ function cachefile() {
     wget -q -O $localname "http://nodejs.org/dist/v$nv/$filename"
     md5sum "$localname" > "$localname.md5"
 
+    # RHEL/centos7 does not ship with a parent shasum function.
+    # Fallback to sha1sum if not found.
+    shasum=""
+    if which shasum > /dev/null; then
+        shasum=$(which shasum)
+    elif which sha1sum > /dev/null; then
+        shasum=$(which sha1sum)
+    fi
+
+    # Check that shasum of tarball is present
+    echo "Verifying nodejs shasum"
+    node_shasum="$($shasum $localname | grep -oE '^[0-9a-f]+')"
+    grep "$node_shasum" "SHASUMS.txt.asc"
+
+    # Check if file already exists on s3
     if aws s3 cp "$dest/v$nv/$filename.md5" "./$localname-online.md5" > /dev/null 2>&1; then
         if md5sum -c $localname-online.md5; then
             echo "$filename unchanged"
@@ -28,9 +43,17 @@ function cachefile() {
     aws s3 cp --acl public-read "$localname.md5"  "$dest/v$nv/$filename.md5"
 }
 
-# Cache app to S3
-gpg -q --keyserver pgp.mit.edu --recv-keys 6C481CF6 && gpg --export --armor 6C481CF6 > "$tmp/izs.asc"
-gpg -q --keyserver pgp.mit.edu --recv-keys 0246406D && gpg --export --armor 0246406D > "$tmp/tjfontaine.asc"
+# Add trusted gpg keys for verifying nodejs downloads
+if which gpg > /dev/null; then
+    echo "Adding trusted keys from pgp.mit.edu"
+    gpg -q --keyserver pgp.mit.edu --recv-keys 6C481CF6 && gpg --export --armor 6C481CF6 > "$tmp/izs.asc"
+    gpg -q --keyserver pgp.mit.edu --recv-keys 0246406D && gpg --export --armor 0246406D > "$tmp/tjfontaine.asc"
+
+    gpg --import "$tmp/izs.asc"
+    gpg --import "$tmp/tjfontaine.asc"
+else
+    echo "!WARN! gpg not found. Please install and try again" && exit 1
+fi
 
 aws s3 cp --acl public-read "$main_file"           $apps_dest/$gitsha/run
 aws s3 cp --acl public-read "$tmp/izs.asc"         $apps_dest/cache/
@@ -48,7 +71,13 @@ cd "$tmp"
 for nv in "${versions[@]}"; do
     echo "Caching Node.js v$nv to S3"
 
-    cachefile SHASUMS.txt.asc $nv
+    # Verify signed SHASUMS file to ensure it can be trusted
+    SHASUMFILE="SHASUMS.txt.asc"
+    wget -q -O $SHASUMFILE "http://nodejs.org/dist/v$nv/$SHASUMFILE"
+
+    echo "Verifying signature of nodejs SHASUMS.txt.asc"
+    gpg --verify < $SHASUMFILE
+
     cachefile node-v$nv-linux-x64.tar.gz $nv
     cachefile node-v$nv-darwin-x64.tar.gz $nv
     cachefile node.exe $nv


### PR DESCRIPTION
In anticipation of https://github.com/mapbox/install-node/issues/24, verifying node packages at mirroring time will ensure that `install_node` is less likely to fail at install time.

cc @yhahn @springmeyer 