### PR TITLE
Local read through cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
-language: python
+language: node_js
+node_js:
+- '0.10'
 env:
   global:
   - AWS_DEFAULT_REGION: us-east-1
   - secure: b+YkS7X50BYrj6/mrKAVkZ8AxjXm1CmHufNUTl3+rp1ktyPubqBSiTOKc/6Zfakdj/77GWTw1q7fGisoScmNKPYvHScQvwBgxWVJD9ZrGqXg6TjSxoD2Iwu7VTB8znrWFCqL7eWJ2/e8cVn4Vdlbxmltsyjy8NY2LVCtJbv/uoQ=
   - secure: V+R+Q0GdZeqpX3A/XeVaQaXJDst8AE/VpwTFI7aIxiHWSYmzD7aoyGLW3bv2DZYOMM8x9XPIxvHlF3yIy5I9G55UMdW0Goi/vK2KiXXSLzV0C4DnS0KPyhNTjPJ5LSWYOWUEcgrsouvPkxMF072WCe1C0+A1JCWcD4mscPB6MR0=
 install:
-- pip install awscli
+- pip install awscli --user && export PATH=$PATH:~/.local/bin/
 script:
 - "./util/recache"
-- "./util/test"
+- npm test
 - sudo mv /usr/bin/gpg /usr/bin/gpg.bak
 - which gpg || echo "Testing without GPG"
-- "./util/test"
+- npm test

--- a/bin/install_node
+++ b/bin/install_node
@@ -2,6 +2,7 @@
 set -eu
 
 bin_only="false"
+cache_dir="false"
 
 if [ -n "${INSTALL_NODE_URL+1}" ]; then
     INSTALL_NODE_URL=$INSTALL_NODE_URL
@@ -16,12 +17,18 @@ if [ -z "${NV+1}" -o -z "${NP+1}" -o -z "${OD+1}" ]; then
     if [ -n "${4+1}" ]; then
         bin_only=$4
     fi
+    if [ -n "${5+1}" ]; then
+        cache_dir=$5
+    fi
 else
     node_version=$NV
     platformarch=$NP
     output_dir=$OD
     if [ -n "${BO+1}" ]; then
         bin_only=$BO
+    fi
+    if [ -n "${CD+1}" ]; then
+        cache_dir=$CD
     fi
 fi
 
@@ -71,7 +78,20 @@ trap "rm -rf $tmp" EXIT
 cd "$tmp"
 
 # Download node
-curl -Lsfo $(basename $url) "$url"
+if [[ "$cache_dir" != "false" && "$platformarch" != "win32-ia32" && "$platformarch" != "win32-x64" ]]; then
+    # Let's cache
+    if [ -e "$cache_dir/$(basename $url)" ]; then
+        # Cache HIT
+        ln -s "$cache_dir/$(basename $url)" "./$(basename $url)"
+    else
+        # Cache MISS
+        curl -Lsfo "$cache_dir/$(basename $url)" "$url"
+        ln -s "$cache_dir/$(basename $url)" "./$(basename $url)"
+    fi
+else
+    # No cache
+    curl -Lsfo "$(basename $url)" "$url"
+fi
 
 # Install node
 if [ "$platformarch" != "win32-ia32" ] && [ "$platformarch" != "win32-x64" ]; then

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Mapbox",
   "license": "ISC",
   "private": true,
+  "scripts": {
+    "test": "for file in ./test/test_*.sh; do $file; done"
+  },
   "bin": {
     "install_node": "./bin/install_node"
   }

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,17 @@ You can point `install_node` add the official node dist endpoint or your own mir
 $ INSTALL_NODE_URL=http://nodejs.org/dist install_node v0.10.33 linux-x64 /usr/local
 ```
 
+## Environment variables
+
+Instead of [above](#Usage) command line interface you can also use environment variables for configuration:
+
+name | description
+-----|------------
+`NV` | node version to install, like `0.10.33`
+`NP` | platform architecture to install for, like `linux-x64`
+`OD` | output directory to install node to
+`BO` | if set to `true`, install only binaries
+
 ## Run from S3
 
 Alternately you can pull the script from S3 with `curl` and run it, specifying

--- a/readme.md
+++ b/readme.md
@@ -55,3 +55,14 @@ If you need to update `install_node` to support a new release of node that isn't
 ## Caveats
 
 - win32 version is nothing but `node.exe`. Plan accordingly.
+
+## Development
+### Tests
+
+- `npm test`
+
+### Push new install_node and node versions to S3
+
+- Make sure your shell is authenticated with AWS
+- Alter S3 destinations if necessary in `./util/recache`
+- Run `./util/recache`

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ without depending on nodejs.org being available.
 ## Usage
 
 ```
-$ install_node <version> <platform+arch> <dir> [bin_only=true|false]
+$ install_node <version> <platform+arch> <dir> [bin_only=true|false] [cache_dir=false|<dir>]
 ```
 
 This will find the corresponding node.js version for the requested `platform+arch`
@@ -14,6 +14,8 @@ This will find the corresponding node.js version for the requested `platform+arc
 
 If the optional fourth `bin_only` arg is set to `true` then only the node binary
 will be installed instead of npm and related resources (headers, man pages, etc.)
+
+If the optional fifth `cache_dir` arg is set to a directory, already downloaded node versions will be read-through cached there for future use.
 
 *Note: the legacy platform (without arch) arguments `linux`, `darwin`, `win32` are
 mapped to the following for backwards compatibility.*
@@ -44,6 +46,7 @@ name | description
 `NP` | platform architecture to install for, like `linux-x64`
 `OD` | output directory to install node to
 `BO` | if set to `true`, install only binaries
+`CD` | if set, use a local cache directory as read-through cache for downloads
 
 ## Run from S3
 

--- a/test/test_install_node.sh
+++ b/test/test_install_node.sh
@@ -178,4 +178,3 @@ if [ "$failed" == "1" ]; then
 else
     exit 0
 fi
-


### PR DESCRIPTION
This adds read-through caching for node versions. Once downloaded, they can be used again. This is especially useful for build systems which need to build many node versions over-and-over again.

/cc @yhahn @rclark 
