### PR TITLE
Deprecate npm/configure

### DIFF
--- a/bin/install_node
+++ b/bin/install_node
@@ -78,5 +78,5 @@ else
     tar --strip-components 1 -xzf "node-v$node_version-$platformarch.tar.gz" --no-same-owner --directory "$output_dir"
     # Change the location of the npm cache so different versions of node don't interfere with each other
     mkdir -p "$output_dir/.npm"
-    "$output_dir/lib/node_modules/npm/configure" --cache="$output_dir/.npm"
+    echo "cache=$output_dir/.npm" >> "$output_dir/lib/node_modules/npm/npmrc"
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-node",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Install node.js",
   "author": "Mapbox",
   "license": "ISC",


### PR DESCRIPTION
I've looked at `npm/configure` a bit closer and realized that our usage scenario can actually be replicated with a one-liner, and the script itself [hasn't changed in the last 11 years](https://github.com/npm/cli/commits/latest/configure), so safe to say it's pretty stable.

What did change is the script was removed from `npm` distribution, and our usage stays the same across all npm versions.

This PR's approach works both for new and old versions and actually does exactly the same thing:
https://github.com/npm/cli/blob/e5761b9adafe8607ad68baa9599ad4eb228bc6be/configure#L32